### PR TITLE
Fixes Clinker refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://clinker.47deg.com/desktop/plugin/public/status/scala-commons-47.png?branch=master)](https://clinker.47deg.com/jenkins/job/scala-commons-47/)
-
 # Scala Commons 47
 
 ## Monad Utils
@@ -88,7 +86,7 @@ Simply add the following dependency to your SBT based build
 
 ```scala
 
-resolvers += "47deg Public" at "http://clinker.47deg.com/nexus/content/groups/public"
+resolvers += "47deg Public" at "https://47degrees.bintray.com/snapshots"
 
 libraryDependencies += "com.fortysevendeg" %% "scala-commons-47" % "0.1-SNAPSHOT" changing()
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,15 +14,7 @@ libraryDependencies ++= Seq(
 
 scalacOptions in Test ++= Seq("-Yrangepos")
 
-credentials += Credentials(new File(Path.userHome.absolutePath + "/.ivy2/.credentials"))
-
 resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
-
-resolvers += "47deg Public" at "http://clinker.47deg.com/nexus/content/groups/public"
-
-resolvers += "47deg Public Snapshot Repository" at "http://clinker.47deg.com/nexus/content/repositories/snapshots"
-
-resolvers += "47deg Public Release Repository" at "http://clinker.47deg.com/nexus/content/repositories/releases"
 
 // Add your own project settings here
 Keys.fork in Test := false
@@ -32,16 +24,6 @@ organization := "com.fortysevendeg"
 organizationName := "47 Degrees"
 
 organizationHomepage := Some(new URL("http://47deg.com"))
-
-publishMavenStyle := true
-
-publishTo <<= version {
-  v: String =>
-    if (v.trim.endsWith("SNAPSHOT"))
-      Some("47deg Public Snapshot Repository" at "http://clinker.47deg.com/nexus/content/repositories/snapshots")
-    else
-      Some("47deg Public Release Repository" at "http://clinker.47deg.com/nexus/content/repositories/releases")
-}
 
 startYear := Some(2014)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,1 @@
 logLevel := Level.Warn
-
-resolvers += "47deg Public Mirror" at "http://clinker.47deg.com/nexus/content/groups/public"
-
-resolvers += "47deg Public Snapshots Repository" at "http://clinker.47deg.com/nexus/content/repositories/public-snapshots"
-
-resolvers += "47deg Public Release Repository" at "http://clinker.47deg.com/nexus/content/repositories/public-releases"


### PR DESCRIPTION
This PR removes the references to Clinker

We should create a ticket to upgrade Scala version and configure for Travis and publishing to Sonatype or Bintray

_Note:_ This library is only available for Scala 2.10

Please @raulraja could you review? Thanks
